### PR TITLE
Support displaying an excerpt of email body, configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ modules: [
                         }
                     ],
                     fade: true,
-                    maxCharacters: 30
+                    maxCharacters: 30,
+		    showBody: true
                 }
 	}
 ]
@@ -104,6 +105,12 @@ The following properties can be configured:
 			<td><code>maxCharacters</code></td>
 			<td>Maximum number of characters to display<br>
 				<br><b>Default value:</b> <code>30</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>showBody</code></td>
+			<td>Should an excerpt of the body be displayed (up to maxCharacters)?<br>
+				<br><b>Default value:</b> <code>false</code>
 			</td>
 		</tr>
 		<tr>

--- a/email.js
+++ b/email.js
@@ -105,19 +105,22 @@ Module.register("email",{
                     senderWrapper.appendChild(addressWrapper);
                     emailWrapper.appendChild(senderWrapper);
 
-                    var subjectWrapper = document.createElement("tr");
+                    var subjectAndBodyWrapper = document.createElement("tr");
+                    subjectAndBodyWrapper.className = "light";   
+                    
+                    var subjectWrapper = document.createElement("td");
                     subjectWrapper.className = "light";
                     subjectWrapper.innerHTML = subject;
-                    emailWrapper.appendChild(subjectWrapper);
-
-                    if (that.config.showBody) {
-                        var body = mailObj.body.replace(/[\['"\]]+/g, "");
-                        body = body.substring(0, that.config.maxCharacters);                    
-                        var bodyWrapper = document.createElement("tr");
-                        bodyWrapper.className = "light";
+                    subjectAndBodyWrapper.appendChild(subjectWrapper);
+                    if (that.config.showBody && mailObj.body) {
+                        var body = mailObj.body.replace(/[\['"\]]+/g, "");                                                                      
+                        body = body.substring(0, that.config.maxCharacters);                                                                    
+                        var bodyWrapper = document.createElement("td");
+                        bodyWrapper.className = "xsmall thin";
                         bodyWrapper.innerHTML = body;
-                        emailWrapper.appendChild(bodyWrapper);
+                        subjectAndBodyWrapper.appendChild(bodyWrapper);
                     }
+                    emailWrapper.appendChild(subjectAndBodyWrapper);   
                     
                     wrapper.appendChild(emailWrapper);
 

--- a/email.js
+++ b/email.js
@@ -14,7 +14,8 @@ Module.register("email",{
     //             authTimeout: 10000,
     //             numberOfEmails: 5,
     //             fade: true,
-    //             maxCharacters: 30
+    //             maxCharacters: 30,
+    //             showBody: false
     //         }
     //     ]
     payload: [],
@@ -109,6 +110,15 @@ Module.register("email",{
                     subjectWrapper.innerHTML = subject;
                     emailWrapper.appendChild(subjectWrapper);
 
+                    if (that.config.showBody) {
+                        var body = mailObj.body.replace(/[\['"\]]+/g, "");
+                        body = body.substring(0, that.config.maxCharacters);                    
+                        var bodyWrapper = document.createElement("tr");
+                        bodyWrapper.className = "light";
+                        bodyWrapper.innerHTML = body;
+                        emailWrapper.appendChild(bodyWrapper);
+                    }
+                    
                     wrapper.appendChild(emailWrapper);
 
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -56,9 +56,11 @@ module.exports = NodeHelper.create({
                                     name: m.from[0].name
                                 }];
                                 var b = m.subject;
+                                var c = m.text;
                                 var tmp = {
                                     sender: a,
                                     subject: b,
+                                    body: c,
                                     id: s,
                                     host: m.to[0].address
                                 };

--- a/notifier.js
+++ b/notifier.js
@@ -74,7 +74,8 @@ Notifier.prototype.scan = function () {
             self.emit('error', err);
             return;
         }
-        seachResults = seachResults.slice(Math.max(seachResults.length - numberOfEmails, 1));
+	dbg('search results: %s', seachResults.length);
+        seachResults = seachResults.slice(0, Math.max(seachResults.length - numberOfEmails, 1));
         if (!seachResults || seachResults.length === 0) {
             dbg('no new mail in %s', self.options.box);
             self.emit('nonew');

--- a/notifier.js
+++ b/notifier.js
@@ -75,7 +75,7 @@ Notifier.prototype.scan = function () {
             return;
         }
 	dbg('search results: %s', seachResults.length);
-        seachResults = seachResults.slice(0, Math.max(seachResults.length - numberOfEmails, 1));
+        seachResults = seachResults.slice(0, Math.min(seachResults.length, numberOfEmails));
         if (!seachResults || seachResults.length === 0) {
             dbg('no new mail in %s', self.options.box);
             self.emit('nonew');

--- a/notifier.js
+++ b/notifier.js
@@ -74,8 +74,10 @@ Notifier.prototype.scan = function () {
             self.emit('error', err);
             return;
         }
-	dbg('search results: %s', seachResults.length);
-        seachResults = seachResults.slice(0, Math.min(seachResults.length, numberOfEmails));
+	dbg('search results: %s', seachResults.length); 
+	var start = Math.max(seachResults.length - numberOfEmails, 0);
+	var end = start + Math.min(seachResults.length, numberOfEmails);
+        seachResults = seachResults.slice(start, end);
         if (!seachResults || seachResults.length === 0) {
             dbg('no new mail in %s', self.options.box);
             self.emit('nonew');


### PR DESCRIPTION
Support displaying an excerpt of email bodies, up to the defined `maxCharacters`, if config is defined with `showBody: true`, otherwise display as before. 