### PR TITLE
Fix bug: getting the correct list of emails

### DIFF
--- a/notifier.js
+++ b/notifier.js
@@ -74,7 +74,7 @@ Notifier.prototype.scan = function () {
             self.emit('error', err);
             return;
         }
-        seachResults = seachResults.slice(Math.max(seachResults.length - numberOfEmails, 1));
+        seachResults = seachResults.slice(0, Math.max(seachResults.length - numberOfEmails, 1));
         if (!seachResults || seachResults.length === 0) {
             dbg('no new mail in %s', self.options.box);
             self.emit('nonew');

--- a/notifier.js
+++ b/notifier.js
@@ -74,7 +74,7 @@ Notifier.prototype.scan = function () {
             self.emit('error', err);
             return;
         }
-        seachResults = seachResults.slice(0, Math.max(seachResults.length - numberOfEmails, 1));
+        seachResults = seachResults.slice(0, Math.min(seachResults.length, numberOfEmails));
         if (!seachResults || seachResults.length === 0) {
             dbg('no new mail in %s', self.options.box);
             self.emit('nonew');

--- a/notifier.js
+++ b/notifier.js
@@ -74,7 +74,9 @@ Notifier.prototype.scan = function () {
             self.emit('error', err);
             return;
         }
-        seachResults = seachResults.slice(0, Math.min(seachResults.length, numberOfEmails));
+        var start = Math.max(seachResults.length - numberOfEmails, 0);
+        var end = start + Math.min(seachResults.length, numberOfEmails);
+        seachResults = seachResults.slice(start, end);    
         if (!seachResults || seachResults.length === 0) {
             dbg('no new mail in %s', self.options.box);
             self.emit('nonew');


### PR DESCRIPTION
The slice was missing the first parameter, defining where to begin the slice, while what should have been the second parameter ("how many emails to bring") became the first one ("where to begin"), thus bringing the wrong list of emails.

Instead, I used a Math.min between the returned number of emails and the desired cap, and Math.max to calculate the first email to display. 